### PR TITLE
Added logic to handle a ? in the path

### DIFF
--- a/tripit-api-client.js
+++ b/tripit-api-client.js
@@ -27,7 +27,10 @@ TripItApiClient.prototype = {
 	},
 
 	requestResource: function (path, method, accessToken, accessTokenSecret) {
-		var url = "https://api.tripit.com/v1" + path + "/format/json";
+		var url = "https://api.tripit.com/v1" + path;
+		if ( ! path.includes('?') ) {
+		    path += "/format/json";
+		}
 		var deferred = Q.defer();
 		this.oauth.getProtectedResource(url, method, accessToken, accessTokenSecret, deferred.makeNodeResolver());
 		return deferred.promise;


### PR DESCRIPTION
TripIt's notification API includes a ? and a query string.
The existing logic added "/format/json" to the path.
The new code checks for a ? in the path and only adds the above if
the hook is not present.