### PR TITLE
Allow support for regular resources as well as TripIt's notification subscription

### DIFF
--- a/tripit-api-client.js
+++ b/tripit-api-client.js
@@ -27,7 +27,10 @@ TripItApiClient.prototype = {
 	},
 
 	requestResource: function (path, method, accessToken, accessTokenSecret) {
-		var url = "https://api.tripit.com/v1" + path + "/format/json";
+		var url = "https://api.tripit.com/v1" + path;
+		if ( ! path.includes('?') ) {
+		    path += "/format/json";
+		}
 		var deferred = Q.defer();
 		this.oauth.getProtectedResource(url, method, accessToken, accessTokenSecret, deferred.makeNodeResolver());
 		return deferred.promise;

--- a/tripit-api-client.js
+++ b/tripit-api-client.js
@@ -29,7 +29,7 @@ TripItApiClient.prototype = {
 	requestResource: function (path, method, accessToken, accessTokenSecret) {
 		var url = "https://api.tripit.com/v1" + path;
 		if ( ! path.includes('?') ) {
-		    path += "/format/json";
+		    url += "/format/json";
 		}
 		var deferred = Q.defer();
 		this.oauth.getProtectedResource(url, method, accessToken, accessTokenSecret, deferred.makeNodeResolver());


### PR DESCRIPTION
From the commit:

TripIt's notification API includes a ? and a query string.
The existing logic added "/format/json" to the path.
The new code checks for a ? in the path and only adds the above if the hook is not present.

I had accidentally pushed the wrong commit including a mistake. This PR replaces that one. And has been tested.